### PR TITLE
Pandas-like Apply() functionality for the db

### DIFF
--- a/src/algbench/__init__.py
+++ b/src/algbench/__init__.py
@@ -32,15 +32,6 @@ from .benchmark import Benchmark
 from .pandas import read_as_pandas, describe
 from .log_capture import JsonLogHandler, JsonLogCapture
 
-# Add __version__ variable from package information.
-# https://packaging-guide.openastronomy.org/en/latest/minimal.html#my-package-init-py
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass  # package is not installed
-
 __all__ = [
     "Benchmark",
     "read_as_pandas",

--- a/src/algbench/benchmark.py
+++ b/src/algbench/benchmark.py
@@ -300,3 +300,19 @@ class Benchmark:
         """
         self._db.apply(func)
         self.compress()
+
+    def __len__(self):
+        """
+        Return the number of fingerprints in the database.
+        It is possible that this does not correspond to the
+        number of entries. Use `__iter__` to iterate over
+        all entries and count them to get the number of entries.
+        However, this is not recommended, as it is slow.
+        """
+        return self._db.__len__()
+    
+    def empty(self):
+        """
+        Return True if the database is empty, False otherwise.
+        """
+        return len(self) == 0

--- a/src/algbench/benchmark.py
+++ b/src/algbench/benchmark.py
@@ -270,7 +270,7 @@ class Benchmark:
 
     def delete_if(self, condition: typing.Callable[[typing.Dict], bool]):
         """
-        Delete entries if a specific condition is met.
+        Delete entries if a specific condition is met (return True).
         Recreates the internal 'results' folder for this porpose. 
         Use `front` to get a preview on how an entry that is
         passed to the condition looks like.
@@ -280,9 +280,9 @@ class Benchmark:
 
         def func(apply_lambda) -> typing.Dict:
             if condition(apply_lambda):
-                return apply_lambda
-            else:
                 return None
+            else:
+                return apply_lambda
 
         self.apply(func)
 

--- a/src/algbench/benchmark.py
+++ b/src/algbench/benchmark.py
@@ -109,7 +109,7 @@ class Benchmark:
         """
         del self._log_captures[logger_name]
 
-    def _get_arg_data(self, func, args, kwargs):
+    def _get_arg_data(self, func, args, kwargs) -> typing.Tuple[str, typing.Dict]:
         sig = inspect.signature(func)
         func_args = {
             k: v.default
@@ -125,8 +125,9 @@ class Benchmark:
                 if not key.startswith("_")
             },
         }
-
-        return fingerprint(data), to_json(data)
+        json_data = to_json(data)
+        assert isinstance(json_data, dict)
+        return fingerprint(data), json_data
 
     def exists(self, func: typing.Callable, *args, **kwargs) -> bool:
         """
@@ -278,15 +279,15 @@ class Benchmark:
         NOT THREAD-SAFE!
         """
 
-        def func(apply_lambda) -> typing.Dict:
-            if condition(apply_lambda):
+        def func(entry) -> typing.Optional[typing.Dict]:
+            if condition(entry):
+                # Delete the entry by returning None
                 return None
-            else:
-                return apply_lambda
+            return entry
 
         self.apply(func)
 
-    def apply(self, func: typing.Callable[[typing.Dict], typing.Dict]):
+    def apply(self, func: typing.Callable[[typing.Dict], typing.Optional[typing.Dict]]):
         """
         Allows to modify all entries (in place !) inside this benchmark, 
         based on the provided callable. It is being called for every

--- a/src/algbench/benchmark.py
+++ b/src/algbench/benchmark.py
@@ -232,7 +232,7 @@ class Benchmark:
 
         NOT THREAD-SAFE!
         """
-        self.delete_if(lambda data: None)
+        self.delete_if(lambda data: False)
 
     def __iter__(self) -> typing.Generator[typing.Dict, None, None]:
         """

--- a/src/algbench/benchmark_db.py
+++ b/src/algbench/benchmark_db.py
@@ -90,9 +90,14 @@ class BenchmarkDb:
         except StopIteration:
             return None
 
-    def apply(self, ):
+    def apply(self, func: typing.Callable[[typing.Dict], typing.Dict]):
         db = NfsJsonList(os.path.join(os.path.join(self.path, "results_apply")))
-        # TODO copy all entries that fulfill the callable thingy
+
+        for entry in self:
+            new_entry = func(entry)
+            if new_entry:
+                self.insert(new_entry)
+        
         self._data.delete()
         db.move_directory(os.path.join(self.path, "results"))
         self._data = db

--- a/src/algbench/benchmark_db.py
+++ b/src/algbench/benchmark_db.py
@@ -89,3 +89,10 @@ class BenchmarkDb:
             return next(self.__iter__())
         except StopIteration:
             return None
+
+    def apply(self, ):
+        db = NfsJsonList(os.path.join(os.path.join(self.path, "results_apply")))
+        # TODO copy all entries that fulfill the callable thingy
+        self._data.delete()
+        db.move_directory(os.path.join(self.path, "results"))
+        self._data = db

--- a/src/algbench/benchmark_db.py
+++ b/src/algbench/benchmark_db.py
@@ -1,5 +1,7 @@
+import datetime
 import json
 import os
+import random
 import shutil
 import sys
 import typing
@@ -96,8 +98,12 @@ class BenchmarkDb:
             return None
 
     def apply(self, func: typing.Callable[[typing.Dict], typing.Dict]):
+        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M")
+        rand = random.randint(0, 9999)
+        old_db_dir = f"results_old{timestamp}_{rand}"
+
         old_db = self._data
-        old_db.move_directory(os.path.join(self.path, "results_old"))
+        old_db.move_directory(os.path.join(self.path, old_db_dir))
         self._data = NfsJsonList(os.path.join(os.path.join(self.path, "results")))
 
         for entry in old_db:

--- a/src/algbench/benchmark_db.py
+++ b/src/algbench/benchmark_db.py
@@ -112,3 +112,6 @@ class BenchmarkDb:
                 self.insert(new_entry)
 
         old_db.delete()
+
+    def __len__(self):
+        return len(self._arg_fingerprints)

--- a/src/algbench/db/nfs_json_dict.py
+++ b/src/algbench/db/nfs_json_dict.py
@@ -58,3 +58,10 @@ class NfsJsonDict:
 
     def delete(self):
         self._db.delete()
+
+    def move_directory(self, new_path: str):
+        """
+        Changes the internal directory of this NFSJsonDict.
+        Not thread safe! 
+        """
+        self._db.move_directory(new_path)

--- a/src/algbench/db/nfs_json_list.py
+++ b/src/algbench/db/nfs_json_list.py
@@ -199,11 +199,11 @@ class NfsJsonList:
         """
 
         if os.path.exists(new_path) or os.path.isfile(new_path):
-            msg = f"Error while moving database to {new_path}: There exists an equally named file or folder"
+            msg = f"Error while moving NFSJsonList database to {new_path}: There exists an equally named file or folder"
             raise RuntimeError(msg)
         shutil.move(self.path, new_path)
 
-        _log.info(f"Moved database from {self.path} to {new_path}.")
+        _log.info(f"Moved NFSJsonList from {self.path} to {new_path}.")
         self._subfile_path = self._get_unique_name()
         self._filesize = 0
         self.path = new_path

--- a/src/algbench/db/nfs_json_list.py
+++ b/src/algbench/db/nfs_json_list.py
@@ -189,3 +189,21 @@ class NfsJsonList:
     def delete(self):
         self._cache.clear()
         shutil.rmtree(self.path)
+
+    def move_directory(self, new_path: str):
+        """
+        Changes the internal directory where the db files are 
+        stored while keeping all files (renames the directory).
+        This operation is not thread safe, especially not
+        over other nodes or instances of this script. 
+        """
+
+        if os.path.exists(new_path) or os.path.isfile(new_path):
+            msg = f"Error while moving database to {new_path}: There exists an equally named file or folder"
+            raise RuntimeError(msg)
+        shutil.move(self.path, new_path)
+
+        _log.info(f"Moved database from {self.path} to {new_path}.")
+        self._subfile_path = self._get_unique_name()
+        self._filesize = 0
+        self.path = new_path

--- a/src/algbench/db/nfs_json_set.py
+++ b/src/algbench/db/nfs_json_set.py
@@ -51,3 +51,10 @@ class NfsJsonSet:
 
     def __len__(self):
         return len(self._values)
+    
+    def move_directory(self, new_path: str):
+        """
+        Changes the internal directory of this NFSJsonSet (essentially 
+        moves the directory). Not thread safe! 
+        """
+        self._db.move_directory(new_path)

--- a/src/algbench/db/nfs_json_set.py
+++ b/src/algbench/db/nfs_json_set.py
@@ -7,6 +7,8 @@ from .nfs_json_list import NfsJsonList
 class NfsJsonSet:
     def __init__(self, path) -> None:
         self._db = NfsJsonList(path)
+        # __values mirrors the database, but is a set
+        # It is expected to be relatively small, so that it can be kept in memory.
         self._values: typing.Set = set()
         self.load()
 
@@ -46,3 +48,6 @@ class NfsJsonSet:
 
     def delete(self):
         self._db.delete()
+
+    def __len__(self):
+        return len(self._values)

--- a/src/algbench/environment.py
+++ b/src/algbench/environment.py
@@ -9,7 +9,6 @@ import typing
 from pathlib import Path
 
 import __main__
-import pkg_resources
 
 __cached = None
 
@@ -54,6 +53,8 @@ def get_environment_info(cached=True) -> dict:
         "python_version": sys.version,
         "python": sys.executable,
         "cwd": Path.cwd(),
+        """
+        # Unfortunately deprecated.
         "environment": [
             {
                 "name": str(pkg.project_name),
@@ -62,6 +63,7 @@ def get_environment_info(cached=True) -> dict:
             }
             for pkg in pkg_resources.working_set
         ],
+        """
         "git_revision": get_git_revision(),
         "python_file": get_python_file(),
     }

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,16 @@
+import os
+from algbench import Benchmark
+
+def test_file_splitting():
+
+    benchmark = Benchmark("./test_apply")
+
+    def generate_entry(args): 
+        return {str(args["index"]) : f"Data for entry {args["index"]}"}
+        
+    for i in range(200):
+        benchmark.add(generate_entry, {"index" : i})
+
+    # assert len(os.listdir("./test_file_split_benchmark/results")) == 4 
+
+    # benchmark.delete()

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,16 +1,38 @@
 import os
+import typing
 from algbench import Benchmark
 
-def test_file_splitting():
+def test_apply():
 
     benchmark = Benchmark("./test_apply")
 
     def generate_entry(args): 
-        return {str(args["index"]) : f"Data for entry {args["index"]}"}
-        
-    for i in range(200):
+        return {"entry_index" : args["index"], "data" : f"Data for entry {args['index']}"}
+    for i in range(20):
         benchmark.add(generate_entry, {"index" : i})
+    
+    benchmark.compress()
 
-    # assert len(os.listdir("./test_file_split_benchmark/results")) == 4 
+    def db_count_entries(b: Benchmark) -> int:
+        return len([0 for _ in b])
 
-    # benchmark.delete()
+    assert db_count_entries(benchmark) == 20
+
+    def func(entry: typing.Dict):
+        if entry["result"]["entry_index"] % 2 == 1:
+            return None
+        else:
+            del entry["timestamp"]
+            del entry["runtime"]
+            return entry
+    benchmark.apply(func)
+
+    assert db_count_entries(benchmark) == 10
+
+    for entry in benchmark:
+        assert "timestamp" not in entry
+        assert "result" in entry
+
+    benchmark.delete()
+
+test_apply()

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -18,6 +18,7 @@ def test_apply():
 
     assert db_count_entries(benchmark) == 20
 
+
     def func(entry: typing.Dict):
         if entry["result"]["entry_index"] % 2 == 1:
             return None
@@ -33,6 +34,9 @@ def test_apply():
         assert "timestamp" not in entry
         assert "result" in entry
 
-    benchmark.delete()
+    benchmark.repair() # implies both a delete_if() and apply() call
+    assert db_count_entries(benchmark) == 10
 
+    benchmark.delete()
+    
 test_apply()

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -38,5 +38,3 @@ def test_apply():
     assert db_count_entries(benchmark) == 10
 
     benchmark.delete()
-    
-test_apply()

--- a/tests/test_extensive.py
+++ b/tests/test_extensive.py
@@ -1,0 +1,34 @@
+from algbench import Benchmark
+
+
+def test_extensive_use_case():
+    benchmark = Benchmark("./test_benchmark")
+    benchmark.clear()
+    assert benchmark.empty()
+
+    def f(x, _test=2, default="default"):
+        print(x)
+        return {"r1": x, "r2": "test"}
+    
+    for x in range(500):
+        benchmark.add(f, x, _test=None)
+
+    assert len(benchmark) == 500
+    for x, entry in enumerate(benchmark):
+        assert entry["result"]["r1"] == x
+    benchmark.compress()
+    assert len(benchmark) == 500
+    benchmark.delete_if(lambda entry: False)
+    assert len(benchmark) == 500
+    benchmark_ = Benchmark("./test_benchmark")
+    assert len(benchmark_) == 500
+    benchmark_.compress()
+    assert len(benchmark_) == 500
+    benchmark_.delete_if(lambda entry: entry["result"]["r1"] % 2 == 0)
+    assert len(benchmark_) == 250
+    for x, entry in enumerate(benchmark_):
+        assert entry["result"]["r1"] == x * 2 + 1
+    benchmark_.compress()
+    assert len(benchmark_) == 250
+    benchmark.delete()
+

--- a/tests/test_extensive.py
+++ b/tests/test_extensive.py
@@ -2,7 +2,7 @@ from algbench import Benchmark
 
 
 def test_extensive_use_case():
-    benchmark = Benchmark("./test_benchmark")
+    benchmark = Benchmark("./extensive_benchmark")
     benchmark.clear()
     assert benchmark.empty()
 
@@ -20,7 +20,7 @@ def test_extensive_use_case():
     assert len(benchmark) == 500
     benchmark.delete_if(lambda entry: False)
     assert len(benchmark) == 500
-    benchmark_ = Benchmark("./test_benchmark")
+    benchmark_ = Benchmark("./extensive_benchmark")
     assert len(benchmark_) == 500
     benchmark_.compress()
     assert len(benchmark_) == 500
@@ -32,3 +32,5 @@ def test_extensive_use_case():
     assert len(benchmark_) == 250
     benchmark.delete()
 
+if __name__=="__main__":
+    test_extensive_use_case()


### PR DESCRIPTION
Note, that unlike Pandas the apply() call does an in-place remplacement of the db-entries. 
One could therefore consider to relabel the function to apply_inplace() instead. 

Also the repair() and delete_if() calls are now powered by the apply() call, which improves their performance. The previous implementation copied the database twice, now data is only copied / rewritten once. 